### PR TITLE
chore: remove duplicated entries from stacktrace query

### DIFF
--- a/grafana/dashboards/proc_history.json
+++ b/grafana/dashboards/proc_history.json
@@ -367,7 +367,7 @@
         {
           "alias": "",
           "format": "table",
-          "rawSql": "SELECT ts, current_function, current_stacktrace FROM prc \nWHERE (ts BETWEEN $__timeFrom() AND $__timeTo()) AND node='[[node]]' AND (pid='[[pid]]' OR registered_name='[[regname]]') AND current_function NOT SIMILAR TO 'gen_server:loop/%'\n",
+          "rawSql": "SELECT DISTINCT ts, current_function, current_stacktrace FROM prc \nWHERE (ts BETWEEN $__timeFrom() AND $__timeTo()) AND node='[[node]]' AND (pid='[[pid]]' OR registered_name='[[regname]]') AND current_function NOT SIMILAR TO 'gen_server:loop/%'\n",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Currently, there are a few duplicate results when querying the stacktrace.